### PR TITLE
Ability to avoid hardcoded DB type

### DIFF
--- a/src/main/scala/com/github/tototoshi/slick/JodaSupport.scala
+++ b/src/main/scala/com/github/tototoshi/slick/JodaSupport.scala
@@ -68,6 +68,7 @@ class GenericJodaSupport(val driver: JdbcDriver) {
 
 }
 
+object JdbcJodaSupport extends GenericJodaSupport(JdbcDriver)
 object H2JodaSupport extends GenericJodaSupport(H2Driver)
 object PostgresJodaSupport extends GenericJodaSupport(PostgresDriver)
 object MySQLJodaSupport extends GenericJodaSupport(MySQLDriver)


### PR DESCRIPTION
First of all - thank you for nice adapter and bunch of other useful libraries, Totoshi.

Since 2.0 slick supports generic JdbcDriver which easily allows to avoid hard-coded dependencies to specific database type. And just one line separates slick-joda-mapper from using in - here is this line. 
