### PR TITLE
Update to Slick 3.0-RC1, imports to slick from scala.slick and reactive queries

### DIFF
--- a/project/SlickJodaMapperBuild.scala
+++ b/project/SlickJodaMapperBuild.scala
@@ -16,7 +16,7 @@ object SlickJodaMapperBuild extends Build {
       libraryDependencies ++= Seq(
         "joda-time" % "joda-time" % "2.4" % "provided",
         "org.joda" % "joda-convert" % "1.6" % "provided",
-        "com.typesafe.slick" %% "slick" % "3.0.0-M1" % "provided",
+        "com.typesafe.slick" %% "slick" % "3.0.0-RC1" % "provided",
         "com.h2database" % "h2" % "[1.3,)" % "test",
         "org.scalatest" %% "scalatest" % "2.2.0" % "test"
       ),

--- a/src/main/scala/com/github/tototoshi/slick/JodaGetResult.scala
+++ b/src/main/scala/com/github/tototoshi/slick/JodaGetResult.scala
@@ -29,7 +29,7 @@
 package com.github.tototoshi.slick
 
 import com.github.tototoshi.slick.converter.SqlTypeConverter
-import scala.slick.jdbc.{ PositionedResult, GetResult }
+import slick.jdbc.{ PositionedResult, GetResult }
 
 trait JodaGetResult[A, B] {
   self: SqlTypeConverter[A, B] =>

--- a/src/main/scala/com/github/tototoshi/slick/JodaSetParameter.scala
+++ b/src/main/scala/com/github/tototoshi/slick/JodaSetParameter.scala
@@ -29,7 +29,7 @@
 package com.github.tototoshi.slick
 
 import com.github.tototoshi.slick.converter.SqlTypeConverter
-import scala.slick.jdbc.{ PositionedParameters, SetParameter }
+import slick.jdbc.{ PositionedParameters, SetParameter }
 
 trait JodaSetParameter[A, B] {
   self: SqlTypeConverter[A, B] =>

--- a/src/main/scala/com/github/tototoshi/slick/JodaSupport.scala
+++ b/src/main/scala/com/github/tototoshi/slick/JodaSupport.scala
@@ -27,7 +27,7 @@
  */
 package com.github.tototoshi.slick
 
-import scala.slick.driver._
+import slick.driver._
 
 class GenericJodaSupport(val driver: JdbcDriver) {
   protected val dateTimeZoneMapperDelegate = new JodaDateTimeZoneMapper(driver)

--- a/src/main/scala/com/github/tototoshi/slick/JodaTypeMapper.scala
+++ b/src/main/scala/com/github/tototoshi/slick/JodaTypeMapper.scala
@@ -28,11 +28,11 @@
 
 package com.github.tototoshi.slick
 
-import scala.slick.driver.JdbcDriver
+import slick.driver.JdbcDriver
 import org.joda.time._
 import com.github.tototoshi.slick.converter._
 import java.sql._
-import scala.slick.jdbc.{ PositionedResult, PositionedParameters }
+import slick.jdbc.{ PositionedResult, PositionedParameters }
 
 class JodaDateTimeZoneMapper(val driver: JdbcDriver) {
 


### PR DESCRIPTION
Update to 3.0-RC1
Change from driver to driver.api
Change of imports from scala.slick to slick