### PR TITLE
`DateTime` drops timezone in select

### DIFF
--- a/src/main/scala/com/github/tototoshi/slick/Converters.scala
+++ b/src/main/scala/com/github/tototoshi/slick/Converters.scala
@@ -34,7 +34,6 @@ import com.github.tototoshi.slick.converter._
 object Converters {
 
   implicit class WrappedDateTimeZone(z: DateTimeZone) extends JodaDateTimeZoneSqlStringConverter {
-    def toSqlString(): String = toSqlType(z)
   }
 
   implicit class WrappedDateTime(d: DateTime) extends JodaDateTimeSqlTimestampConverter {

--- a/src/main/scala/com/github/tototoshi/slick/JodaTypeMapper.scala
+++ b/src/main/scala/com/github/tototoshi/slick/JodaTypeMapper.scala
@@ -32,6 +32,7 @@ import scala.slick.driver.JdbcDriver
 import org.joda.time._
 import com.github.tototoshi.slick.converter._
 import java.sql._
+import java.util.Calendar
 import scala.slick.jdbc.{ PositionedResult, PositionedParameters }
 
 class JodaDateTimeZoneMapper(val driver: JdbcDriver) {
@@ -94,7 +95,7 @@ class JodaDateTimeMapper(val driver: JdbcDriver) {
     def zero = new DateTime(0L)
     def sqlType = java.sql.Types.TIMESTAMP
     override def setValue(v: DateTime, p: PreparedStatement, idx: Int): Unit =
-      p.setTimestamp(idx, toSqlType(v))
+      p.setTimestamp(idx, toSqlType(v), Calendar.getInstance(v.getZone().toTimeZone()))
     override def getValue(r: ResultSet, idx: Int): DateTime =
       fromSqlType(r.getTimestamp(idx))
     override def updateValue(v: DateTime, r: ResultSet, idx: Int): Unit =

--- a/src/main/scala/com/github/tototoshi/slick/JodaTypeMapper.scala
+++ b/src/main/scala/com/github/tototoshi/slick/JodaTypeMapper.scala
@@ -73,7 +73,7 @@ class JodaLocalDateMapper(val driver: JdbcDriver) {
       fromSqlType(r.getDate(idx))
     override def updateValue(v: LocalDate, r: ResultSet, idx: Int): Unit =
       r.updateDate(idx, toSqlType(v))
-    override def valueToSQLLiteral(value: LocalDate) = "{d '" + toSqlType(value).toString + "'}"
+    override def valueToSQLLiteral(value: LocalDate) = "{d '" + toSqlString(value) + "'}"
   }
 
   object JodaGetResult extends JodaGetResult[java.sql.Date, LocalDate] with JodaLocalDateSqlDateConverter {
@@ -100,7 +100,7 @@ class JodaDateTimeMapper(val driver: JdbcDriver) {
       fromSqlType(r.getTimestamp(idx))
     override def updateValue(v: DateTime, r: ResultSet, idx: Int): Unit =
       r.updateTimestamp(idx, toSqlType(v))
-    override def valueToSQLLiteral(value: DateTime) = "{ts '" + toSqlType(value).toString + "'}"
+    override def valueToSQLLiteral(value: DateTime) = "{ts '" + toSqlString(value) + "'}"
   }
 
   object JodaGetResult extends JodaGetResult[Timestamp, DateTime] with JodaDateTimeSqlTimestampConverter {
@@ -127,7 +127,7 @@ class JodaInstantMapper(val driver: JdbcDriver) {
       fromSqlType(r.getTimestamp(idx))
     override def updateValue(v: Instant, r: ResultSet, idx: Int): Unit =
       r.updateTimestamp(idx, toSqlType(v))
-    override def valueToSQLLiteral(value: Instant) = "{ts '" + toSqlType(value).toString + "'}"
+    override def valueToSQLLiteral(value: Instant) = "{ts '" + toSqlString(value) + "'}"
   }
 
   object JodaGetResult extends JodaGetResult[Timestamp, Instant] with JodaInstantSqlTimestampConverter {
@@ -154,7 +154,7 @@ class JodaLocalDateTimeMapper(val driver: JdbcDriver) {
       fromSqlType(r.getTimestamp(idx))
     override def updateValue(v: LocalDateTime, r: ResultSet, idx: Int): Unit =
       r.updateTimestamp(idx, toSqlType(v))
-    override def valueToSQLLiteral(value: LocalDateTime) = "{ts '" + toSqlType(value).toString + "'}"
+    override def valueToSQLLiteral(value: LocalDateTime) = "{ts '" + toSqlString(value) + "')"
   }
 
   object JodaGetResult extends JodaGetResult[Timestamp, LocalDateTime] with JodaLocalDateTimeSqlTimestampConverter {
@@ -181,7 +181,7 @@ class JodaLocalTimeMapper(val driver: JdbcDriver) {
       fromSqlType(r.getTime(idx))
     override def updateValue(v: LocalTime, r: ResultSet, idx: Int): Unit =
       r.updateTime(idx, toSqlType(v))
-    override def valueToSQLLiteral(value: LocalTime) = "{t '" + toSqlType(value).toString + "'}"
+    override def valueToSQLLiteral(value: LocalTime) = "{t '" + toSqlString(value) + "'}"
   }
 
   object JodaGetResult extends JodaGetResult[Time, LocalTime] with JodaLocalTimeSqlTimeConverter {

--- a/src/main/scala/com/github/tototoshi/slick/JodaTypeMapper.scala
+++ b/src/main/scala/com/github/tototoshi/slick/JodaTypeMapper.scala
@@ -100,7 +100,8 @@ class JodaDateTimeMapper(val driver: JdbcDriver) {
       fromSqlType(r.getTimestamp(idx))
     override def updateValue(v: DateTime, r: ResultSet, idx: Int): Unit =
       r.updateTimestamp(idx, toSqlType(v))
-    override def valueToSQLLiteral(value: DateTime) = "{ts '" + toSqlString(value) + "'}"
+    override def valueToSQLLiteral(value: DateTime) =
+      "(timestamp with time zone '" + toSqlString(value) + "')"
   }
 
   object JodaGetResult extends JodaGetResult[Timestamp, DateTime] with JodaDateTimeSqlTimestampConverter {

--- a/src/main/scala/com/github/tototoshi/slick/converter/JodaSqlTypeCoverter.scala
+++ b/src/main/scala/com/github/tototoshi/slick/converter/JodaSqlTypeCoverter.scala
@@ -28,6 +28,7 @@
 package com.github.tototoshi.slick.converter
 
 import org.joda.time._
+import org.joda.time.format.DateTimeFormatterBuilder
 import java.sql.{ Timestamp, Time }
 
 trait JodaDateTimeZoneSqlStringConverter
@@ -54,12 +55,32 @@ trait JodaLocalDateSqlDateConverter
 trait JodaDateTimeSqlTimestampConverter
     extends SqlTypeConverter[Timestamp, DateTime] {
 
+  val formatter =
+    new DateTimeFormatterBuilder()
+      .appendYear(4, 4)
+      .appendLiteral('-')
+      .appendMonthOfYear(2)
+      .appendLiteral('-')
+      .appendDayOfMonth(2)
+      .appendLiteral(' ')
+      .appendHourOfDay(2)
+      .appendLiteral(':')
+      .appendMinuteOfHour(2)
+      .appendLiteral(':')
+      .appendSecondOfMinute(2)
+      .appendLiteral('.')
+      .appendMillisOfSecond(3)
+      .appendTimeZoneOffset("Z", true, 2, 2)
+      .toFormatter
+
   def fromSqlType(t: java.sql.Timestamp): DateTime =
     if (t == null) null else new DateTime(t.getTime)
 
   def toSqlType(t: DateTime): java.sql.Timestamp =
     if (t == null) null else new java.sql.Timestamp(t.getMillis)
 
+  override def toSqlString(d: DateTime): String =
+    if (d == null) null else d.toString(formatter)
 }
 
 trait JodaInstantSqlTimestampConverter

--- a/src/main/scala/com/github/tototoshi/slick/converter/SqlTypeConverter.scala
+++ b/src/main/scala/com/github/tototoshi/slick/converter/SqlTypeConverter.scala
@@ -38,6 +38,8 @@ trait ToTypeConverter[A, B] {
 
   def toSqlType(b: B): A
 
+  def toSqlString(b: B): String = toSqlType(b).toString
+
   def millisToSqlType(d: { def getTime(): Long }): java.sql.Date = {
     import java.util.Calendar
     val cal = Calendar.getInstance()


### PR DESCRIPTION
So, unfortunately, it seems like `DateTime`'s `valueToSQLLiteral` drops the timezone when converting to a JDBC timestamp:

    val now = DateTime.now

    val driver = play.api.db.slick.Config.driver
    val jdtm = new JodaDateTimeMapper(driver)
    println(s"here: ${jdtm.TypeMapper.valueToSQLLiteral(now)}")
    // Prints: {ts '2015-07-30 12:05:33.652'}

Unfortunately, this causes problems with even the most basic of database round-tripping:

    println("  > delete")
    entries.delete
    println("  < delete")

    println("  > insert")
    entries.insert(Entry(created_on = now)
    println("  < insert")

    println("  > select")
    val q = (
      entries
        .filter(_.created_on <= now)
        .map(_.id)
    )

    println(q.selectStatement)
    // prints: select x2."id" from (x3."id" as "id" from "feed_entry" x3 where x3."created_on" <= {ts '2015-07-30 12:05:33.652'}) x2

    val res = q.run
    println("  < select")

    println(s"res: $res")
    // prints Vector()

[Some digging](http://stackoverflow.com/questions/9202857/timezones-in-sql-date-vs-java-sql-date#answer-9305468) suggests that `java.sql.Timestamp` is a point in time _without_ a timezone, so calling `toSqlType(value).toString` drops the timezone, then wrapping that in the JDBC encoding of `{ts '...'}` further ensures that the database knows of it only as "a point of time". Without the timezone attached, database configuration enters the game, and errors occur.

My proposal here is to continue @dk8996's work for string encoding as well, using Joda's `DateTimeFormatterBuilder` to build a `timestamp with time zone`, representing the `DateTime`. This solves the problems I was encountering, although I'm not sure it's portable.

Comments are definitely welcome.