### PR TITLE
Add base trait for improved driver abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,10 @@ import scala.slick.codegen.SourceCodeGenerator
 
 class CustomSourceCodeGenerator(model: m.Model) extends SourceCodeGenerator(model) {
 
+  override def parentType: Option[String] = Some("com.github.tototoshi.slick.BaseGenericJodaSupport")
   // add some custom imports
-  // TODO: fix these imports to refer to your JdbcSupport and your Joda imports
-  override def code = "import com.github.tototoshi.slick.PostgresJodaSupport._\n" + "import org.joda.time.DateTime\n" + super.code
+  // TODO: fix these imports to refer to your Joda imports
+  override def code = "import org.joda.time.DateTime\n" + super.code
 
   override def Table = new Table(_) {
     override def Column = new Column(_) {

--- a/src/main/scala/com/github/tototoshi/slick/JodaSupport.scala
+++ b/src/main/scala/com/github/tototoshi/slick/JodaSupport.scala
@@ -29,13 +29,19 @@ package com.github.tototoshi.slick
 
 import slick.driver._
 
-class GenericJodaSupport(val driver: JdbcProfile) {
-  protected val dateTimeZoneMapperDelegate = new JodaDateTimeZoneMapper(driver)
-  protected val localDateMapperDelegate = new JodaLocalDateMapper(driver)
-  protected val dateTimeMapperDelegate = new JodaDateTimeMapper(driver)
-  protected val instantMapperDelegate = new JodaInstantMapper(driver)
-  protected val localDateTimeMapperDelegate = new JodaLocalDateTimeMapper(driver)
-  protected val localTimeMapperDelegate = new JodaLocalTimeMapper(driver)
+class GenericJodaSupport(val driver: JdbcProfile) extends BaseGenericJodaSupport {
+  def profile = driver
+}
+
+trait BaseGenericJodaSupport {
+  def profile: JdbcProfile
+
+  protected val dateTimeZoneMapperDelegate = new JodaDateTimeZoneMapper(profile)
+  protected val localDateMapperDelegate = new JodaLocalDateMapper(profile)
+  protected val dateTimeMapperDelegate = new JodaDateTimeMapper(profile)
+  protected val instantMapperDelegate = new JodaInstantMapper(profile)
+  protected val localDateTimeMapperDelegate = new JodaLocalDateTimeMapper(profile)
+  protected val localTimeMapperDelegate = new JodaLocalTimeMapper(profile)
 
   implicit val dateTimeZoneTypeMapper = dateTimeZoneMapperDelegate.TypeMapper
   implicit val getDateTimeZoneResult = dateTimeZoneMapperDelegate.JodaGetResult.getResult
@@ -80,3 +86,9 @@ object PostgresJodaSupport extends GenericJodaSupport(PostgresDriver)
 object MySQLJodaSupport extends GenericJodaSupport(MySQLDriver)
 object HsqldbJodaSupport extends GenericJodaSupport(HsqldbDriver)
 object SQLiteJodaSupport extends GenericJodaSupport(SQLiteDriver)
+
+trait H2JodaSupport extends BaseGenericJodaSupport { def profile = H2Driver }
+trait PostgresJodaSupport extends BaseGenericJodaSupport { def profile = PostgresDriver }
+trait MySQLJodaSupport extends BaseGenericJodaSupport { def profile = MySQLDriver }
+trait HsqldbJodaSupport extends BaseGenericJodaSupport { def profile = HsqldbDriver }
+trait SQLiteJodaSupport extends BaseGenericJodaSupport { def profile = SQLiteDriver }

--- a/src/test/scala/com/github/tototoshi/slick/JodaSupportSpec.scala
+++ b/src/test/scala/com/github/tototoshi/slick/JodaSupportSpec.scala
@@ -38,7 +38,7 @@ import java.util.{ TimeZone, Locale }
 
 abstract class JodaSupportSpec(
   val driver: JdbcProfile,
-  val jodaSupport: GenericJodaSupport,
+  val jodaSupport: BaseGenericJodaSupport,
   val jdbcUrl: String,
   val jdbcDriver: String,
   val jdbcUser: String,
@@ -222,4 +222,6 @@ abstract class JodaSupportSpec(
 
 import slick.driver._
 
-class H2JodaSupportSpec extends JodaSupportSpec(H2Driver, H2JodaSupport, "jdbc:h2:mem:testh2;DB_CLOSE_DELAY=-1", "org.h2.Driver", "sa", null)
+class H2JodaSupportObjectSpec extends JodaSupportSpec(H2Driver, H2JodaSupport, "jdbc:h2:mem:testh2;DB_CLOSE_DELAY=-1", "org.h2.Driver", "sa", null)
+
+class H2JodaSupportTraitSpec extends JodaSupportSpec(H2Driver, new H2JodaSupport {}, "jdbc:h2:mem:testh2;DB_CLOSE_DELAY=-1", "org.h2.Driver", "sa", null)


### PR DESCRIPTION
I'm currently using Slick Code Generator 
which by default generates a trait with a abstract member of type JdbcProfile. 

I think if we have a trait for GenericJodaSupport it would be better. 
Also, we can support cake pattern, too. 

This PR is a bit related with #36 #37 

For backward compatibility, I just added new traits without changing any existing interfaces. 
