### PR TITLE
upgrade to latest release of Slick (3.2.0)

### DIFF
--- a/project/SlickJodaMapperBuild.scala
+++ b/project/SlickJodaMapperBuild.scala
@@ -9,7 +9,7 @@ object SlickJodaMapperBuild extends Build {
     settings = Defaults.coreDefaultSettings ++ Seq(
       name := "slick-joda-mapper",
       organization := "com.github.tototoshi",
-      version := "2.2.0",
+      version := "2.3.0",
       crossScalaVersions ++= Seq("2.10.6", "2.11.7"),
       scalaVersion := "2.11.7",
       scalacOptions ++= Seq("-deprecation", "-language:_"),
@@ -18,7 +18,7 @@ object SlickJodaMapperBuild extends Build {
         "org.joda" % "joda-convert" % "1.7" % "provided",
         "com.h2database" % "h2" % "[1.4,)" % "test",
         "org.scalatest" %% "scalatest" % "2.2.3" % "test",
-        "com.typesafe.slick" %% "slick" % "3.1.1" % "provided"
+        "com.typesafe.slick" %% "slick" % "3.2.0" % "provided"
       ),
       initialCommands += """
         import com.github.tototoshi.slick.JodaSupport._

--- a/src/main/scala/com/github/tototoshi/slick/JodaSupport.scala
+++ b/src/main/scala/com/github/tototoshi/slick/JodaSupport.scala
@@ -27,7 +27,7 @@
  */
 package com.github.tototoshi.slick
 
-import slick.driver._
+import slick.jdbc._
 
 class GenericJodaSupport(val driver: JdbcProfile) {
   protected val dateTimeZoneMapperDelegate = new JodaDateTimeZoneMapper(driver)
@@ -75,8 +75,8 @@ class GenericJodaSupport(val driver: JdbcProfile) {
 
 }
 
-object H2JodaSupport extends GenericJodaSupport(H2Driver)
-object PostgresJodaSupport extends GenericJodaSupport(PostgresDriver)
-object MySQLJodaSupport extends GenericJodaSupport(MySQLDriver)
-object HsqldbJodaSupport extends GenericJodaSupport(HsqldbDriver)
-object SQLiteJodaSupport extends GenericJodaSupport(SQLiteDriver)
+object H2JodaSupport extends GenericJodaSupport(H2Profile)
+object PostgresJodaSupport extends GenericJodaSupport(PostgresProfile)
+object MySQLJodaSupport extends GenericJodaSupport(MySQLProfile)
+object HsqldbJodaSupport extends GenericJodaSupport(HsqldbProfile)
+object SQLiteJodaSupport extends GenericJodaSupport(SQLiteProfile)

--- a/src/main/scala/com/github/tototoshi/slick/JodaTypeMapper.scala
+++ b/src/main/scala/com/github/tototoshi/slick/JodaTypeMapper.scala
@@ -28,7 +28,7 @@
 
 package com.github.tototoshi.slick
 
-import slick.driver.JdbcProfile
+import slick.jdbc.JdbcProfile
 import org.joda.time._
 import com.github.tototoshi.slick.converter._
 import java.sql._

--- a/src/test/scala/com/github/tototoshi/slick/JodaSupportSpec.scala
+++ b/src/test/scala/com/github/tototoshi/slick/JodaSupportSpec.scala
@@ -31,8 +31,7 @@ import org.scalatest.{ BeforeAndAfter, FunSpec }
 import org.scalatest._
 import org.joda.time._
 import scala.concurrent.ExecutionContext.Implicits.global
-import slick.driver.JdbcProfile
-import slick.jdbc.GetResult
+import slick.jdbc.{ GetResult, JdbcProfile }
 import slick.jdbc.ActionBasedSQLInterpolation._
 import java.util.{ TimeZone, Locale }
 
@@ -220,6 +219,6 @@ abstract class JodaSupportSpec(
   }
 }
 
-import slick.driver._
+import slick.jdbc.H2Profile
 
-class H2JodaSupportSpec extends JodaSupportSpec(H2Driver, H2JodaSupport, "jdbc:h2:mem:testh2;DB_CLOSE_DELAY=-1", "org.h2.Driver", "sa", null)
+class H2JodaSupportSpec extends JodaSupportSpec(H2Profile, H2JodaSupport, "jdbc:h2:mem:testh2;DB_CLOSE_DELAY=-1", "org.h2.Driver", "sa", null)


### PR DESCRIPTION
This PR just bumps the version of Slick this plugin is compiled against. The other changes are just fixes for the deprecation warnings.