### PR TITLE
fix warning

### DIFF
--- a/src/main/scala/com/github/tototoshi/slick/converter/SqlTypeConverter.scala
+++ b/src/main/scala/com/github/tototoshi/slick/converter/SqlTypeConverter.scala
@@ -41,7 +41,7 @@ trait ToTypeConverter[A, B] {
   def millisToSqlType(d: { def getTime(): Long }): java.sql.Date = {
     import java.util.Calendar
     val cal = Calendar.getInstance()
-    cal.setTimeInMillis(d.getTime)
+    cal.setTimeInMillis(d.getTime())
     cal.set(Calendar.HOUR_OF_DAY, 0)
     cal.set(Calendar.MINUTE, 0)
     cal.set(Calendar.SECOND, 0)


### PR DESCRIPTION
```
[warn] /home/runner/work/slick-joda-mapper/slick-joda-mapper/src/main/scala/com/github/tototoshi/slick/converter/SqlTypeConverter.scala:44:27: Auto-application to `()` is deprecated. Supply the empty argument list `()` explicitly to invoke method getTime,
[warn] or remove the empty argument list from its definition (Java-defined methods are exempt).
[warn] In Scala 3, an unapplied method like this will be eta-expanded into a function.
[warn]     cal.setTimeInMillis(d.getTime)
[warn]                           ^
[warn] one warning found
```