### PR TITLE
remove sbt-dotty plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,14 +34,14 @@ lazy val `slick-joda-mapper` = project.in(file("."))
       "joda-time" % "joda-time" % "2.10.10" % "provided",
       "org.joda" % "joda-convert" % "2.2.1" % "provided",
       "com.h2database" % "h2" % "1.4.200" % "test",
-      "com.dimafeng" %% "testcontainers-scala" % "0.39.5" % "test" withDottyCompat scalaVersion.value,
+      "com.dimafeng" %% "testcontainers-scala" % "0.39.5" % "test" cross CrossVersion.for3Use2_13,
       "mysql" % "mysql-connector-java" % "8.0.25" % "test",
       "org.postgresql" % "postgresql" % "42.2.20" % "test",
       "org.testcontainers" % "mysql" % testContainerVersion % "test",
       "org.testcontainers" % "postgresql" % testContainerVersion % "test",
       "org.slf4j" % "slf4j-simple" % "1.7.30" % "test",
       "org.scalatest" %% "scalatest" % "3.2.9" % "test",
-      "com.typesafe.slick" %% "slick" % "3.3.3" % "provided" withDottyCompat scalaVersion.value
+      "com.typesafe.slick" %% "slick" % "3.3.3" % "provided" cross CrossVersion.for3Use2_13
     ),
     initialCommands += """
       import org.joda.time._

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,3 @@ scalacOptions += "-deprecation"
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.7")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.5")


### PR DESCRIPTION
```
/home/runner/work/slick-joda-mapper/slick-joda-mapper/build.sbt:37: warning: method withDottyCompat in class DottyCompatModuleID is deprecated (since 0.5.5): Use `.cross(CrossVersion.for3Use2_13)` instead, available in sbt >= 1.5.0 (cf https://eed3si9n.com/sbt-1.5.0)
      "com.dimafeng" %% "testcontainers-scala" % "0.39.5" % "test" withDottyCompat scalaVersion.value,
                                                                   ^
/home/runner/work/slick-joda-mapper/slick-joda-mapper/build.sbt:44: warning: method withDottyCompat in class DottyCompatModuleID is deprecated (since 0.5.5): Use `.cross(CrossVersion.for3Use2_13)` instead, available in sbt >= 1.5.0 (cf https://eed3si9n.com/sbt-1.5.0)
      "com.typesafe.slick" %% "slick" % "3.3.3" % "provided" withDottyCompat scalaVersion.value
                                                             ^
```