### PR TITLE
use new `&` syntax instead of `with`

### DIFF
--- a/src/test/scala/com/github/tototoshi/slick/JodaSupportSpec.scala
+++ b/src/test/scala/com/github/tototoshi/slick/JodaSupportSpec.scala
@@ -273,7 +273,7 @@ class H2JodaSupportSpec extends JodaSupportSpec {
 }
 
 abstract class TestContainerSpec extends JodaSupportSpec with ForAllTestContainer {
-  override def container: JdbcDatabaseContainer with Container
+  override def container: JdbcDatabaseContainer & Container
   override def jdbcUrl = container.jdbcUrl
   override def jdbcUser = container.username
   override def jdbcPassword = container.password
@@ -284,7 +284,7 @@ object MySQLJodaSupportSpec {
 }
 
 class MySQLJodaSupportSpec extends TestContainerSpec {
-  override val container: JdbcDatabaseContainer with Container = MySQLContainer(
+  override val container: JdbcDatabaseContainer & Container = MySQLContainer(
     configurationOverride = "test-mysql-conf",
     mysqlImageVersion = DockerImageName.parse(MySQLJodaSupportSpec.mySQLDockerImageName)
   )
@@ -295,7 +295,7 @@ class MySQLJodaSupportSpec extends TestContainerSpec {
 }
 
 class MySQLJodaSupportWithoutCalenderSpec extends TestContainerSpec {
-  override val container: JdbcDatabaseContainer with Container = MySQLContainer(mysqlImageVersion = DockerImageName.parse(MySQLJodaSupportSpec.mySQLDockerImageName))
+  override val container: JdbcDatabaseContainer & Container = MySQLContainer(mysqlImageVersion = DockerImageName.parse(MySQLJodaSupportSpec.mySQLDockerImageName))
   override def jdbcDriver = "com.mysql.jdbc.Driver"
   override val driver: JdbcProfile = MySQLProfile
   override val jodaSupport: GenericJodaSupport = new GenericJodaSupport(MySQLProfile, _ => None)
@@ -303,7 +303,7 @@ class MySQLJodaSupportWithoutCalenderSpec extends TestContainerSpec {
 }
 
 class PostgresJodaSupportSpec extends TestContainerSpec {
-  override val container: JdbcDatabaseContainer with Container = PostgreSQLContainer()
+  override val container: JdbcDatabaseContainer & Container = PostgreSQLContainer()
   override def jdbcDriver = "org.postgresql.Driver"
   override val driver: JdbcProfile = PostgresProfile
   override val jodaSupport: GenericJodaSupport = PostgresJodaSupport


### PR DESCRIPTION
```
Welcome to Scala 3.5.1-RC2 (21.0.4, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                             
scala> trait A; trait B
// defined trait A
// defined trait B
                                                                                                                                             
scala> def x: A with B = ???
1 warning found
-- [E003] Syntax Warning: ------------------------------------------------------
1 |def x: A with B = ???
  |         ^^^^
  |         with as a type operator has been deprecated; use & instead
  |
  | longer explanation available when compiling with `-explain`
def x: A & B
                                                                                                                                             
scala> def x: A & B = ???
def x: A & B
```